### PR TITLE
 HipChat appears to use a different username pattern now 

### DIFF
--- a/hipchat-helper.pl
+++ b/hipchat-helper.pl
@@ -41,7 +41,7 @@ sub plugin_load {
 sub received_chat_msg_cb {
     my ($account, $sender, $message, $conv, $flag, $data) = @_;
 
-    if ($account->get_username() !~ m|chat.hipchat.com/xmpp$| 
+    if ($account->get_username() !~ m|chat.hipchat.com/(xmpp)?$| 
 	or $message !~ m/(&lt;|&gt;)/) {
 	Purple::Debug::info(
 	    'hipchat-helper-plugin',


### PR DESCRIPTION
The plugin checks for xmpp at the end of the hipchat username before stripping it, but the messages coming from Jenkins and GitHub do not have xmpp in the username.  I changed the pattern to only optionally match the xmpp and it now works perfectly for me.

Thanks for this pidgin plugin!
