### PR TITLE
Add replacing of buddy names with @nick on send

### DIFF
--- a/hipchat-helper.pl
+++ b/hipchat-helper.pl
@@ -9,7 +9,7 @@ use HTML::Entities;
     name => "Hipchat Helper Plugin",
     version => "0.1",
     summary => "Hipchat support plugin",
-    description => "Currently just decodes html.",
+    description => "Decodes html, auto-replaces buddy names with @nicks.",
     author => "Christof Damian <christof@damian.net>",
     url => "http://christof.damian.net/",
     load => "plugin_load",
@@ -24,18 +24,30 @@ sub plugin_load {
     my $plugin = shift;
     Purple::Debug::info('hipchat-helper-plugin',"Hipchat Helper Plugin loaded\n");
 
-    foreach my $account (Purple::Accounts::get_all()) {
-	my $conversation_handle = Purple::Conversations::get_handle();
-	Purple::Signal::connect(
-	    $conversation_handle, 
-	    "receiving-chat-msg", 
-	    $plugin, 
-	    \&received_chat_msg_cb, 
-	    "receivedd chat message"
-	    );
-	
-	Purple::Debug::info('hipchat-helper-plugin',"connected to ".$account->get_username()."\n");
+    my $conversation_handle = Purple::Conversations::get_handle();
+    Purple::Signal::connect(
+        $conversation_handle,
+        "receiving-chat-msg",
+        $plugin,
+        \&received_chat_msg_cb,
+        "received chat message"
+        );
+
+    Purple::Signal::connect(
+        $conversation_handle,
+        "sending-chat-msg",
+        $plugin,
+        \&sending_msg,
+        $plugin);
+
+    my $jabber = Purple::Find::prpl("prpl-jabber");
+    if (!$jabber) {
+        warn("No jabber protocol?, weird: $!\n");
     }
+    Purple::Signal::connect($jabber, "jabber-receiving-iq",$plugin,\&got_iq, 0);
+    Purple::Signal::connect($jabber, "jabber-receiving-presence",$plugin,\&got_presence, 0);
+
+    Purple::Debug::info('hipchat-helper-plugin',"connected\n");
 }
 
 sub received_chat_msg_cb {
@@ -69,6 +81,54 @@ sub received_chat_msg_cb {
     );
 
     $_[2] = $stripped_message;
+}
+
+## Cache of user ids (jids) to the info we need for generating @nicks
+my %jids;
+
+sub got_presence {
+    my ($conn, $type, $from, $node) = @_;
+    my $item = $node->get_child("x")->get_child("item");
+    if($item) {
+        my $jid = $item->get_attrib("jid");
+        Purple::Debug::info('hipchat-helper-plugin', "XML PRES from: $from, jid: $jid\n");
+        if($jid =~ /@chat.hipchat.com$/ && !$jids{$jid}) {
+            # Request vCard for this jid
+            my $id = "req-" . int(rand(100000));
+            my $xml = "<iq type='get' id='$id' to='$jid'><vCard xmlns='vcard-temp'/></iq>";
+            Purple::Debug::info('hipchat-helper-plugin', "SEND $xml via $conn\n");
+            Purple::Prpl::send_raw($conn, $xml);
+        }
+    }
+    return true;
+}
+
+sub got_iq {
+    my ($conn, $type, $id, $from, $node, $soughtid) = @_;
+    my $vcard = $node->get_child("vCard");
+    if($vcard) {
+        # Got a vCard -- add relevant entry to cache
+        my $jid = $node->get_attrib("from");
+        my $name = $vcard->get_child("FN")->get_data();
+        my $at = $vcard->get_child("NICKNAME")->get_data();
+        Purple::Debug::info('hipchat-helper-plugin', "XML IQ $from, $name, $at\n");
+        if($name && $at) {
+            $jids{$jid} = {'name'=>$name, 'at'=>$at};
+        }
+    }
+    return true;
+}
+
+sub sending_msg {
+    my ($account, $message, $id, $plugin) = @_;
+    if ($account->get_username() =~ m|chat.hipchat.com/(xmpp)?$|) {
+        ## Replace name with @nick, for all cached names
+        foreach my $jid (values(%jids)) {
+            $name = $jid->{'name'};
+            $at = '@' . $jid->{'at'};
+            $_[1] =~ s|\b$name\b|$at|g;
+        }
+    }
 }
 
 sub plugin_unload {


### PR DESCRIPTION
This allows you to use pidgin's normal autocomplete to write out the names of people in a hipchat chatroom, but when you send the message have it sent using the appropriate @nick-style nicknames so that those users will be notified in the standard hipchat way.

This is a rather substantial change, so if you have any objections to the approach or anything other thoughts or comments, well -- that would all be completely understandable. :-)

--Chouser
